### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/reminders.yml
+++ b/.github/workflows/reminders.yml
@@ -11,6 +11,8 @@ concurrency:
   group: reminders
   cancel-in-progress: false
 
+permissions: {}
+
 jobs:
   trigger:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Jhin1808/SmartGrocery-Lite/security/code-scanning/2](https://github.com/Jhin1808/SmartGrocery-Lite/security/code-scanning/2)

Add an explicit `permissions` block to `.github/workflows/reminders.yml` at the workflow root, before `jobs:`.  
For this workflow, the safest least-privilege setting is an empty map (`permissions: {}`), which disables all `GITHUB_TOKEN` scopes. The job only calls an external API using `CRON_SECRET` and does not require repository API access, so this does not change intended functionality while removing unnecessary implicit token privileges.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
