### PR TITLE
Allow Koyeb runtime secret fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,7 @@ DATABASE_URL=postgresql://postgres:postgres@db:5432/smartgrocery
 SECRET_KEY=change_me_at_least_32_chars_in_prod
 # JWT_SECRET or JWT_SECRET_KEY are also accepted aliases for SECRET_KEY.
 # SESSION_SECRET is optional when SECRET_KEY/JWT_SECRET_KEY/JWT_SECRET is set.
+# Koyeb can generate a runtime-only fallback if these are omitted.
 SESSION_SECRET=change_me_at_least_32_chars_in_prod
 REQUIRE_STRONG_SECRETS=0
 COOKIE_SECURE=0

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -795,7 +795,7 @@ Renders branded HTML email: SmartGrocery header with blue gradient, code display
 | `DB_POOL_SIZE` / `DB_MAX_OVERFLOW` | `1` / `0` | Connection pool tuning |
 | `OAUTH_TOKEN_IN_FRAGMENT` | `0` | Include JWT in URL fragment (Safari fallback) |
 
-Koyeb/backend deploys must set one JWT signing secret: prefer `SECRET_KEY`, or reuse an existing `JWT_SECRET_KEY`/`JWT_SECRET`. Use at least 32 random characters. `SESSION_SECRET` can be omitted when one of those JWT signing secrets is set.
+Koyeb/backend deploys should set one JWT signing secret for stable sessions: prefer `SECRET_KEY`, or reuse an existing `JWT_SECRET_KEY`/`JWT_SECRET`. Use at least 32 random characters. `SESSION_SECRET` can be omitted when one of those JWT signing secrets is set. If all signing secrets are omitted on Koyeb, the backend generates a runtime-only fallback secret so the app can start, but users may be logged out after restarts or instance changes.
 
 ### Frontend Variables (`REACT_APP_*`)
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,8 +1,10 @@
 import os
+import secrets
 from urllib.parse import urlparse
 
 
 LOCAL_HOSTS = {"localhost", "127.0.0.1", "::1", "0.0.0.0"}
+_EPHEMERAL_SECRET_CACHE: dict[str, str] = {}
 
 
 def env_flag(name: str, default: bool = False) -> bool:
@@ -89,6 +91,22 @@ def is_production_like() -> bool:
     return _public_url_configured(os.getenv("FRONTEND_URL"))
 
 
+def is_koyeb_environment() -> bool:
+    return any(name.startswith("KOYEB_") for name in os.environ)
+
+
+def _get_ephemeral_secret(names: tuple[str, ...], min_length: int) -> str:
+    for name in names:
+        value = _EPHEMERAL_SECRET_CACHE.get(name)
+        if value:
+            return value
+
+    value = secrets.token_urlsafe(max(32, min_length))
+    for name in names:
+        _EPHEMERAL_SECRET_CACHE[name] = value
+    return value
+
+
 def load_secret(
     primary_name: str,
     *,
@@ -107,6 +125,8 @@ def load_secret(
             return value
 
     if is_production_like():
+        if is_koyeb_environment() and not env_flag("REQUIRE_STRONG_SECRETS"):
+            return _get_ephemeral_secret(checked, min_length)
         names = " or ".join(checked)
         raise RuntimeError(f"{names} must be set in production")
     return dev_default

--- a/backend/app/tests/test_security_hardening.py
+++ b/backend/app/tests/test_security_hardening.py
@@ -1,11 +1,21 @@
 import pytest
 
 
+def _clear_koyeb_env(monkeypatch):
+    import os
+
+    for name in list(os.environ):
+        if name.startswith("KOYEB_"):
+            monkeypatch.delenv(name, raising=False)
+
+
 def _restore_import_secret_state(monkeypatch):
     import importlib
+    import app.config as config
     import app.main as main
     import app.security as security
 
+    _clear_koyeb_env(monkeypatch)
     monkeypatch.setenv("DATABASE_URL", "sqlite:///./.pytest-test.db")
     monkeypatch.setenv("SECRET_KEY", "test-secret-key-for-suite-32-bytes")
     monkeypatch.setenv("SESSION_SECRET", "test-session-secret-for-suite-32")
@@ -13,6 +23,7 @@ def _restore_import_secret_state(monkeypatch):
     monkeypatch.delenv("JWT_SECRET_KEY", raising=False)
     monkeypatch.delenv("JWT_SECRET", raising=False)
 
+    importlib.reload(config)
     importlib.reload(security)
     importlib.reload(main)
 
@@ -20,8 +31,10 @@ def _restore_import_secret_state(monkeypatch):
 def test_public_deployment_rejects_default_secrets(monkeypatch):
     from app.config import load_secret
 
+    _clear_koyeb_env(monkeypatch)
     monkeypatch.delenv("SECRET_KEY", raising=False)
     monkeypatch.delenv("JWT_SECRET_KEY", raising=False)
+    monkeypatch.delenv("JWT_SECRET", raising=False)
     monkeypatch.setenv("FRONTEND_URL", "https://smartgrocery.online")
 
     with pytest.raises(RuntimeError, match="SECRET_KEY"):
@@ -30,6 +43,31 @@ def test_public_deployment_rejects_default_secrets(monkeypatch):
             fallback_names=("JWT_SECRET_KEY",),
             dev_default="change-me-in-dev",
         )
+
+
+def test_koyeb_deployment_can_generate_runtime_secret_when_missing(monkeypatch):
+    import importlib
+
+    try:
+        monkeypatch.delenv("SECRET_KEY", raising=False)
+        monkeypatch.delenv("JWT_SECRET_KEY", raising=False)
+        monkeypatch.delenv("JWT_SECRET", raising=False)
+        monkeypatch.delenv("SESSION_SECRET", raising=False)
+        monkeypatch.setenv("FRONTEND_URL", "https://smartgrocery.online")
+        monkeypatch.setenv("KOYEB_APP_NAME", "smartgrocery-lite")
+
+        import app.config as config
+        import app.security as security
+        import app.main as main
+
+        importlib.reload(config)
+        security = importlib.reload(security)
+        main = importlib.reload(main)
+
+        assert len(security.SECRET_KEY) >= 32
+        assert main.SESSION_SECRET == security.SECRET_KEY
+    finally:
+        _restore_import_secret_state(monkeypatch)
 
 
 def test_jwt_secret_alias_is_accepted_in_public_deployment(monkeypatch):


### PR DESCRIPTION
## Summary
- Allow Koyeb deploys with no configured JWT/session signing secret to generate a runtime-only in-memory secret so startup does not fail.
- Keep normal public production deploys protected by the existing missing-secret failure.
- Document the Koyeb fallback and add regression coverage for the no-secret Koyeb startup case.

## Notes
- A real `SECRET_KEY`, `JWT_SECRET_KEY`, or `JWT_SECRET` is still recommended for stable sessions across restarts or multiple instances.
- If all signing secrets are omitted on Koyeb, users may be logged out after restarts because the fallback is not persisted.

## Validation
- `python -m pytest app\tests -p no:cacheprovider` passed: 71 tests.
- Koyeb-style import check passed with no signing secret set and `KOYEB_APP_NAME` present.
- `git diff --check` passed with only CRLF conversion warnings.