### PR TITLE
Improve list item search UI

### DIFF
--- a/frontend/src/components/ItemTypeahead.jsx
+++ b/frontend/src/components/ItemTypeahead.jsx
@@ -11,10 +11,73 @@ function useDebounced(value, delay = 300) {
   return v;
 }
 
+function norm(s) {
+  return (s || "").toString().toLowerCase().trim();
+}
+
+function scoreMatch(p, q) {
+  if (!q) return -1;
+  const name = norm(p.name);
+  const brand = norm(p.brand);
+  const display = norm(p.display);
+  const cat = norm(p.canonical);
+  const tokens = q.split(/\s+/).filter(Boolean);
+  if (tokens.length === 0) return -1;
+
+  let score = 0;
+  let allTokensContained = true;
+  for (const t of tokens) {
+    let tokenBest = 0;
+    if (name === t) tokenBest = Math.max(tokenBest, 1000);
+    else if (name.startsWith(t)) tokenBest = Math.max(tokenBest, 600);
+    else if (new RegExp(`\\b${escapeRegExp(t)}`).test(name)) tokenBest = Math.max(tokenBest, 400);
+    else if (name.includes(t)) tokenBest = Math.max(tokenBest, 200);
+
+    if (brand && brand.includes(t)) tokenBest = Math.max(tokenBest, 80);
+    if (display && display.includes(t)) tokenBest = Math.max(tokenBest, 40);
+    if (cat && cat.includes(t)) tokenBest = Math.max(tokenBest, 30);
+
+    if (tokenBest === 0) allTokensContained = false;
+    score += tokenBest;
+  }
+  if (!allTokensContained) return -1;
+  return score;
+}
+
+function escapeRegExp(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function highlightMatch(text, q) {
+  if (!text || !q) return text || "";
+  const tokens = q.split(/\s+/).filter(Boolean).map(escapeRegExp);
+  if (tokens.length === 0) return text;
+  const re = new RegExp(`(${tokens.join("|")})`, "ig");
+  const parts = text.split(re);
+  return parts.map((p, i) =>
+    re.test(p) ? (
+      <mark key={i} className="lm-typeahead__match">{p}</mark>
+    ) : (
+      <React.Fragment key={i}>{p}</React.Fragment>
+    )
+  );
+}
+
+function matchQuality(p, q) {
+  const name = norm(p.name);
+  if (name === q) return "exact";
+  if (name.startsWith(q)) return "starts";
+  const re = new RegExp(`\\b${escapeRegExp(q)}`);
+  if (re.test(name)) return "word";
+  if (name.includes(q)) return "partial";
+  return "fuzzy";
+}
+
 export default function ItemTypeahead({
   value,
   onChange,
   onPick,
+  onSubmitCustom,
   disabled,
   placeholder = "Search or type an item…",
   autoFocus = false,
@@ -27,6 +90,7 @@ export default function ItemTypeahead({
   const [loading, setLoading] = useState(false);
   const [active, setActive] = useState(-1);
   const [error, setError] = useState("");
+  const [hasExactMatch, setHasExactMatch] = useState(false);
   const debounced = useDebounced(value, 300);
   const wrapRef = useRef(null);
   const inputRef = useRef(null);
@@ -45,45 +109,77 @@ export default function ItemTypeahead({
   useEffect(() => {
     if (!FEATURE_CATALOG) {
       setResults([]);
+      setHasExactMatch(false);
       return;
     }
     const q = (debounced || "").trim();
     if (q.length < minChars) {
       setResults([]);
       setError("");
+      setHasExactMatch(false);
       return;
     }
     const id = ++reqIdRef.current;
     setLoading(true);
     setError("");
-    apiCatalogSearch({ q, category, pageSize: maxResults })
+    apiCatalogSearch({ q, category, pageSize: maxResults * 2 })
       .then((rows) => {
         if (id !== reqIdRef.current) return;
-        setResults(Array.isArray(rows) ? rows.slice(0, maxResults) : []);
+        const arr = Array.isArray(rows) ? rows : [];
+        const scored = arr
+          .map((p) => ({ p, s: scoreMatch(p, q), quality: matchQuality(p, q) }))
+          .filter((x) => x.s > 0)
+          .sort((a, b) => b.s - a.s)
+          .slice(0, maxResults)
+          .map((x) => ({ ...x.p, _quality: x.quality }));
+        setResults(scored);
+        setHasExactMatch(scored.some((x) => x._quality === "exact" || x._quality === "starts"));
         setOpen(true);
       })
       .catch((e) => {
         if (id !== reqIdRef.current) return;
         setError(e?.message || "Search failed");
         setResults([]);
+        setHasExactMatch(false);
       })
       .finally(() => {
         if (id === reqIdRef.current) setLoading(false);
       });
   }, [debounced, category, maxResults, minChars]);
 
+  const q = (value || "").trim();
+  const showAddCustom = q.length >= minChars && !hasExactMatch && onSubmitCustom;
+  const menuItemCount = results.length + (error ? 1 : 0) + (q.length >= minChars && !loading ? 1 : 0) + (showAddCustom ? 1 : 0);
+
   const onKeyDown = (e) => {
-    if (!open || results.length === 0) return;
     if (e.key === "ArrowDown") {
+      if (menuItemCount === 0) return;
       e.preventDefault();
-      setActive((i) => Math.min(i + 1, results.length - 1));
-    } else if (e.key === "ArrowUp") {
+      setOpen(true);
+      setActive((i) => Math.min(i + 1, menuItemCount - 1));
+      return;
+    }
+    if (e.key === "ArrowUp") {
+      if (menuItemCount === 0) return;
       e.preventDefault();
       setActive((i) => Math.max(i - 1, 0));
-    } else if (e.key === "Enter" && active >= 0) {
-      e.preventDefault();
-      handlePick(results[active]);
-    } else if (e.key === "Escape") {
+      return;
+    }
+    if (e.key === "Enter") {
+      // If a result is highlighted, pick it.
+      if (active >= 0 && active < results.length) {
+        e.preventDefault();
+        handlePick(results[active]);
+        return;
+      }
+      // Otherwise: if no exact match, fall back to custom.
+      if (q.length >= minChars && showAddCustom) {
+        e.preventDefault();
+        handleCustom();
+        return;
+      }
+    }
+    if (e.key === "Escape") {
       setOpen(false);
     }
   };
@@ -92,6 +188,13 @@ export default function ItemTypeahead({
     setOpen(false);
     setActive(-1);
     if (onPick) onPick(p);
+  }
+
+  function handleCustom() {
+    if (!onSubmitCustom || !q) return;
+    setOpen(false);
+    setActive(-1);
+    onSubmitCustom(q);
   }
 
   return (
@@ -111,7 +214,7 @@ export default function ItemTypeahead({
           setOpen(true);
           setActive(-1);
         }}
-        onFocus={() => { if (results.length > 0) setOpen(true); }}
+        onFocus={() => { if (results.length > 0 || showAddCustom) setOpen(true); }}
         onKeyDown={onKeyDown}
         style={{ height: 40, paddingRight: 28 }}
       />
@@ -120,11 +223,23 @@ export default function ItemTypeahead({
           <span className="lm-spinner" />
         </span>
       )}
-      {open && (results.length > 0 || error) && (
+      {open && (results.length > 0 || error || (q.length >= minChars && !loading)) && (
         <div className="lm-typeahead__menu" role="listbox">
           {error && <div className="lm-typeahead__error">{error}</div>}
+
+          {results.length === 0 && !error && q.length >= minChars && !loading && (
+            <div className="lm-typeahead__empty">
+              <i className="bi bi-info-circle" />
+              <span>
+                No matches for <strong>&ldquo;{q}&rdquo;</strong> in the catalog. You can still add it as a custom item.
+              </span>
+            </div>
+          )}
+
           {results.map((p, i) => {
             const color = categoryColor(p.canonical);
+            const quality = p._quality || "fuzzy";
+            const isExact = quality === "exact" || quality === "starts";
             return (
               <button
                 key={`${p.source}-${p.code || i}`}
@@ -144,7 +259,14 @@ export default function ItemTypeahead({
                   )}
                 </div>
                 <div className="lm-typeahead__body">
-                  <div className="lm-typeahead__name truncate">{p.name || "Unknown"}</div>
+                  <div className="lm-typeahead__name truncate">
+                    {highlightMatch(p.name || "Unknown", q)}
+                    {isExact ? (
+                      <span className="lm-typeahead__match-badge" style={{ marginLeft: 6 }}>
+                        <i className="bi bi-stars" /> Best match
+                      </span>
+                    ) : null}
+                  </div>
                   <div className="lm-typeahead__meta">
                     {p.brand && <span className="lm-typeahead__brand">{p.brand}</span>}
                     {p.display && (
@@ -155,7 +277,7 @@ export default function ItemTypeahead({
                     )}
                     {(p.weight_value != null && p.weight_value > 0) && (
                       <span className="lm-typeahead__weight">
-                        <i className="bi bi-box" />
+                        <i className="bi bi-rulers" />
                         {p.weight_value}{p.weight_unit || ""}
                       </span>
                     )}
@@ -167,6 +289,21 @@ export default function ItemTypeahead({
               </button>
             );
           })}
+
+          {showAddCustom && (
+            <button
+              type="button"
+              className="lm-typeahead__add"
+              onMouseDown={(e) => { e.preventDefault(); handleCustom(); }}
+              onMouseEnter={() => setActive(results.length)}
+            >
+              <i className="bi bi-plus-circle-fill" />
+              <span className="lm-typeahead__add-label">
+                Add &ldquo;<em>{q}</em>&rdquo; as a custom item
+              </span>
+              <i className="bi bi-arrow-return" />
+            </button>
+          )}
         </div>
       )}
     </div>

--- a/frontend/src/components/WeightDisplay.jsx
+++ b/frontend/src/components/WeightDisplay.jsx
@@ -10,11 +10,10 @@ const UNIT_LABELS = {
   l: "L",
 };
 
-function fmt(value, unit) {
+function fmt(value) {
   if (value == null) return null;
   let n = Number(value);
   if (!isFinite(n) || n <= 0) return null;
-  // Trim trailing zeros for cleaner display
   let s = (Math.round(n * 100) / 100).toString();
   if (s.includes(".") && !s.endsWith(".5")) {
     s = s.replace(/\.?0+$/, "");
@@ -22,15 +21,29 @@ function fmt(value, unit) {
   return s;
 }
 
-export default function WeightDisplay({ value, unit, fallback = null, compact = true }) {
-  const num = fmt(value, unit);
+export default function WeightDisplay({
+  value,
+  unit,
+  fallback = null,
+  compact = true,
+  showLabel = true,
+  label = "Size",
+  className = "",
+}) {
+  const num = fmt(value);
   if (num == null) return fallback;
   const u = unit ? (UNIT_LABELS[String(unit).toLowerCase()] || unit) : null;
-  if (!u) return <span className="lm-weight-pill">{num}</span>;
+  const titleParts = ["Size"];
+  if (num != null) titleParts.push(`${num}${u ? " " + u : ""}`);
+  const display = u ? `${num} ${u}` : `${num}`;
   return (
-    <span className="lm-weight-pill" title={`${num} ${u}`}>
-      <i className="bi bi-box" />
-      {compact ? <span>{num}{u}</span> : <span>{num} {u}</span>}
+    <span
+      className={`lm-weight-pill ${className}`}
+      title={titleParts.join(": ")}
+    >
+      <i className="bi bi-rulers" />
+      {showLabel && <span className="lm-weight-pill__label">{label}</span>}
+      <span>{display}</span>
     </span>
   );
 }

--- a/frontend/src/pages/ListDetail.jsx
+++ b/frontend/src/pages/ListDetail.jsx
@@ -167,6 +167,10 @@ export default function ListDetail() {
     setDraft((d) => ({ ...d, ...fields, name: d.name || fields.name }));
     setShowDetails(true);
   };
+  const submitCustomName = (name) => {
+    setDraft((d) => ({ ...d, name }));
+    setShowDetails(false);
+  };
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -368,6 +372,7 @@ export default function ListDetail() {
                   value={draft.name}
                   onChange={(v) => updateDraft({ name: v })}
                   onPick={applyProductToDraft}
+                  onSubmitCustom={submitCustomName}
                   placeholder="Add an item or search the catalog…"
                   autoFocus
                 />
@@ -622,14 +627,17 @@ export default function ListDetail() {
                     <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
                       {isEd ? (
                         <>
-                          <input
-                            type="number"
-                            min="1"
-                            className="form-control"
-                            value={edit.quantity}
-                            onChange={(e) => setEdit((s) => ({ ...s, quantity: e.target.value }))}
-                            style={{ width: 80, height: 34, textAlign: "center", fontSize: 13.5 }}
-                          />
+                          <div className="lm-item__qty-edit" title="Quantity">
+                            <i className="bi bi-123" />
+                            <input
+                              type="number"
+                              min="1"
+                              className="form-control"
+                              value={edit.quantity}
+                              onChange={(e) => setEdit((s) => ({ ...s, quantity: e.target.value }))}
+                              aria-label="Quantity"
+                            />
+                          </div>
                           <input
                             type="date"
                             className="form-control"
@@ -640,7 +648,11 @@ export default function ListDetail() {
                         </>
                       ) : (
                         <>
-                          <span className="lm-item__qty">×{it.quantity}</span>
+                          <span className="lm-item__qty" title={`Quantity: ${it.quantity}`}>
+                            <i className="bi bi-123" />
+                            <span className="lm-item__qty-label">Qty</span>
+                            <span className="lm-item__qty-value">{it.quantity}</span>
+                          </span>
                           <ExpiryPill expiry={it.expiry} />
                         </>
                       )}

--- a/frontend/src/theme.css
+++ b/frontend/src/theme.css
@@ -929,27 +929,44 @@ textarea.form-control { resize: vertical; min-height: 60px; line-height: 1.5; }
 .lm-item.is-purchased .lm-item__name { text-decoration: line-through; color: var(--text-muted); }
 
 .lm-item__check {
-  width: 22px;
-  height: 22px;
+  width: 24px;
+  height: 24px;
   border-radius: 50%;
   border: 2px solid var(--border-strong);
-  display: inline-grid;
-  place-items: center;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   background: var(--surface);
   transition: all var(--t-fast) var(--ease-out);
   cursor: pointer;
   flex-shrink: 0;
-  color: var(--surface);
+  color: transparent;
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--surface) 70%, transparent);
+  position: relative;
 }
 
-.lm-item__check:hover { border-color: var(--color-primary); }
+.lm-item__check:hover {
+  border-color: var(--color-primary);
+  color: var(--color-primary);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--color-primary) 18%, transparent);
+}
 .lm-item__check.is-checked {
   background: var(--color-primary);
   border-color: var(--color-primary);
+  color: var(--text-on-brand);
+  box-shadow: 0 2px 6px color-mix(in srgb, var(--color-primary) 30%, transparent),
+              inset 0 1px 0 color-mix(in srgb, var(--text-on-brand) 20%, transparent);
 }
+.lm-item__check.is-checked:hover { background: var(--color-primary-hover); border-color: var(--color-primary-hover); }
 
-.lm-item__check i { font-size: 14px; opacity: 0; transition: opacity var(--t-fast) var(--ease-out); }
-.lm-item__check.is-checked i { opacity: 1; }
+.lm-item__check i {
+  font-size: 15px;
+  line-height: 1;
+  opacity: 0;
+  transform: scale(0.6);
+  transition: opacity var(--t-fast) var(--ease-out), transform var(--t-fast) var(--ease-out);
+}
+.lm-item__check.is-checked i { opacity: 1; transform: scale(1); }
 
 .lm-item__main { min-width: 0; display: flex; flex-direction: column; gap: 4px; }
 
@@ -976,14 +993,54 @@ textarea.form-control { resize: vertical; min-height: 60px; line-height: 1.5; }
 .lm-item__qty {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
-  padding: 4px 10px;
-  background: var(--surface-hover);
+  gap: 4px;
+  padding: 3px 9px 3px 7px;
+  background: color-mix(in srgb, var(--color-accent) 12%, transparent);
+  color: var(--color-accent-hover);
+  border: 1px solid color-mix(in srgb, var(--color-accent) 30%, transparent);
   border-radius: var(--radius-full);
-  font-size: 12px;
+  font-size: 11.5px;
   font-weight: 700;
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.01em;
+}
+.lm-item__qty i { font-size: 11px; opacity: 0.9; }
+.lm-item__qty-label {
+  font-size: 9.5px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  opacity: 0.75;
+  padding-right: 4px;
+  border-right: 1px solid currentColor;
+  margin-right: 3px;
+}
+.lm-item__qty-value { font-size: 12px; }
+.lm-item__qty-edit {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 0 6px 0 8px;
+  background: color-mix(in srgb, var(--color-accent) 12%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-accent) 30%, transparent);
+  border-radius: var(--radius-md);
+  color: var(--color-accent-hover);
+  height: 34px;
+}
+.lm-item__qty-edit i { font-size: 12px; }
+.lm-item__qty-edit .form-control {
+  width: 64px;
+  height: 28px;
+  border: 0;
+  background: transparent;
+  text-align: center;
+  font-weight: 700;
+  font-size: 13.5px;
+  padding: 0;
   color: var(--text);
 }
+.lm-item__qty-edit .form-control:focus { box-shadow: none; }
 
 .lm-item__actions {
   display: inline-flex;
@@ -1047,22 +1104,35 @@ textarea.form-control { resize: vertical; min-height: 60px; line-height: 1.5; }
 .lm-shop-card.is-purchased .lm-shop-card__name { text-decoration: line-through; color: var(--text-muted); }
 
 .lm-shop-card__check {
-  width: 26px;
-  height: 26px;
+  width: 28px;
+  height: 28px;
   border-radius: 8px;
   border: 2px solid var(--border-strong);
-  display: inline-grid;
-  place-items: center;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   background: var(--surface);
-  color: var(--surface);
+  color: transparent;
   transition: all var(--t-fast) var(--ease-out);
   flex-shrink: 0;
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--surface) 70%, transparent);
 }
+.lm-shop-card:hover .lm-shop-card__check { border-color: var(--color-primary); }
 .lm-shop-card.is-purchased .lm-shop-card__check {
   background: var(--color-primary);
   border-color: var(--color-primary);
   color: var(--text-on-brand);
+  box-shadow: 0 2px 6px color-mix(in srgb, var(--color-primary) 30%, transparent),
+              inset 0 1px 0 color-mix(in srgb, var(--text-on-brand) 20%, transparent);
 }
+.lm-shop-card__check i {
+  font-size: 16px;
+  line-height: 1;
+  opacity: 0;
+  transform: scale(0.6);
+  transition: opacity var(--t-fast) var(--ease-out), transform var(--t-fast) var(--ease-out);
+}
+.lm-shop-card.is-purchased .lm-shop-card__check i { opacity: 1; transform: scale(1); }
 
 .lm-shop-card__main { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 4px; }
 .lm-shop-card__name { font-size: 15px; font-weight: 600; color: var(--text); }
@@ -2109,22 +2179,34 @@ textarea.form-control { resize: vertical; min-height: 60px; line-height: 1.5; }
 .lm-cat-badge--lg { font-size: 13px; padding: 5px 12px 5px 9px; }
 .lm-cat-badge--lg i { font-size: 13px; }
 
-/* Weight pill */
+/* Weight / size pill */
 .lm-weight-pill {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
-  padding: 2px 8px;
+  gap: 5px;
+  padding: 2px 9px 2px 7px;
   border-radius: var(--radius-full);
   font-size: 11.5px;
   font-weight: 600;
-  background: var(--surface-hover);
-  color: var(--text);
-  border: 1px solid var(--border);
+  background: color-mix(in srgb, var(--info, #3b82f6) 10%, transparent);
+  color: var(--info, #3b82f6);
+  border: 1px solid color-mix(in srgb, var(--info, #3b82f6) 28%, transparent);
   white-space: nowrap;
   letter-spacing: -0.01em;
+  font-variant-numeric: tabular-nums;
 }
-.lm-weight-pill i { font-size: 11px; color: var(--text-muted); }
+.lm-weight-pill i { font-size: 11px; opacity: 0.9; }
+.lm-weight-pill__label {
+  font-size: 9.5px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  opacity: 0.7;
+  padding-right: 3px;
+  border-right: 1px solid currentColor;
+  margin-right: 2px;
+}
+[data-theme="dark"] .lm-weight-pill { color: #93c5fd; }
 
 /* Price pill */
 .lm-price-pill {
@@ -2215,7 +2297,7 @@ textarea.form-control { resize: vertical; min-height: 60px; line-height: 1.5; }
   border-radius: var(--radius-md);
   box-shadow: var(--shadow-lg);
   overflow: hidden;
-  max-height: 360px;
+  max-height: 400px;
   overflow-y: auto;
 }
 .lm-typeahead__error {
@@ -2223,6 +2305,84 @@ textarea.form-control { resize: vertical; min-height: 60px; line-height: 1.5; }
   font-size: 12.5px;
   color: var(--danger, #ef4444);
   background: color-mix(in srgb, var(--danger, #ef4444) 8%, transparent);
+}
+.lm-typeahead__empty {
+  padding: 14px;
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  font-size: 13px;
+  color: var(--text-muted);
+  background: var(--surface-hover);
+  border-bottom: 1px solid var(--border);
+}
+.lm-typeahead__empty i {
+  color: var(--text-muted);
+  font-size: 16px;
+  flex-shrink: 0;
+  margin-top: 1px;
+}
+.lm-typeahead__empty strong {
+  color: var(--text);
+  font-weight: 600;
+}
+.lm-typeahead__add {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  background: var(--color-primary-soft);
+  border: 0;
+  border-top: 1px solid color-mix(in srgb, var(--color-primary) 22%, transparent);
+  cursor: pointer;
+  text-align: left;
+  color: var(--color-primary);
+  font-size: 13.5px;
+  font-weight: 600;
+  transition: background var(--t-fast) var(--ease-out);
+}
+.lm-typeahead__add:hover { background: color-mix(in srgb, var(--color-primary) 16%, transparent); }
+.lm-typeahead__add i { font-size: 15px; }
+.lm-typeahead__add-label {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.lm-typeahead__add-label em {
+  font-style: normal;
+  background: color-mix(in srgb, var(--color-primary) 28%, transparent);
+  border-radius: 3px;
+  padding: 1px 3px;
+  font-weight: 700;
+}
+.lm-typeahead__match {
+  background: color-mix(in srgb, var(--color-primary) 24%, transparent);
+  color: var(--color-primary);
+  border-radius: 3px;
+  padding: 0 2px;
+  font-weight: 700;
+}
+[data-theme="dark"] .lm-typeahead__match { color: var(--text); }
+.lm-typeahead__match-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  font-size: 9.5px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  padding: 1px 6px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--color-primary) 16%, transparent);
+  color: var(--color-primary);
+  flex-shrink: 0;
+}
+.lm-typeahead__match-badge--partial {
+  background: var(--surface-hover);
+  color: var(--text-muted);
 }
 .lm-typeahead__item {
   --cat-color: var(--cat-default);
@@ -2288,6 +2448,13 @@ textarea.form-control { resize: vertical; min-height: 60px; line-height: 1.5; }
   align-items: center;
   gap: 3px;
   font-variant-numeric: tabular-nums;
+  color: var(--info, #3b82f6);
+  background: color-mix(in srgb, var(--info, #3b82f6) 10%, transparent);
+  padding: 1px 7px;
+  border-radius: var(--radius-full);
+  font-size: 10.5px;
+  font-weight: 600;
+  border: 1px solid color-mix(in srgb, var(--info, #3b82f6) 24%, transparent);
 }
 .lm-typeahead__src {
   font-size: 9.5px;


### PR DESCRIPTION
## Summary
- Improve catalog typeahead ranking, highlighting, and empty-result handling.
- Add a custom-item fallback from the typeahead when no strong catalog match exists.
- Polish quantity and size pills in list item views.

## Impact
This makes item entry feel clearer and more forgiving while preserving the catalog-backed workflow.

## Validation
- `npm run build` from `frontend/` completed successfully.
- Build still reports existing `@zxing` source-map warnings for missing package source files.