### PR TITLE
Fix list creation and share action layout

### DIFF
--- a/frontend/src/pages/EnhancedLists.jsx
+++ b/frontend/src/pages/EnhancedLists.jsx
@@ -674,10 +674,21 @@ export default function EnhancedLists() {
     try {
       setCreating(true);
       const created = await safeCreateList(nm);
+      const createdList = created?.id
+        ? { hidden: false, owner_id: me?.id, name: nm, ...created }
+        : null;
       setNewListName("");
       const data = await safeGetLists(showHidden);
-      setLists(Array.isArray(data) ? data : []);
-      if (created?.id) setSelectedId(created.id);
+      const refreshed = Array.isArray(data) ? data : [];
+      const nextLists = createdList && !refreshed.some((list) => list.id === createdList.id)
+        ? [createdList, ...refreshed]
+        : refreshed;
+      setLists(nextLists);
+      setListQuery("");
+      if (createdList?.id) {
+        setSelectedId(createdList.id);
+        setItemsByList((m) => ({ ...m, [createdList.id]: m[createdList.id] || [] }));
+      }
       pushToast({ message: `Created "${created?.name || nm}"`, variant: "success" });
     } catch (e) {
       pushToast({ message: e.message || "Couldn't create list", variant: "danger" });
@@ -1085,17 +1096,21 @@ export default function EnhancedLists() {
                             {total === 0 ? "Empty" : `${pending} pending · ${total} total`}
                           </span>
                         </div>
-                        {pending > 0 && <span className="lm-badge lm-badge--brand">{pending}</span>}
-                        {isListOwner && (
-                          <button
-                            type="button"
-                            className="lm-list__item-share"
-                            aria-label={`Share ${list.name}`}
-                            title="Share list"
-                            onClick={(e) => { e.stopPropagation(); openShare(list.id); }}
-                          >
-                            <i className="bi bi-share" />
-                          </button>
+                        {(pending > 0 || isListOwner) && (
+                          <div className="lm-list__item-actions">
+                            {pending > 0 && <span className="lm-badge lm-badge--brand">{pending}</span>}
+                            {isListOwner && (
+                              <button
+                                type="button"
+                                className="lm-list__item-share"
+                                aria-label={`Share ${list.name}`}
+                                title="Share list"
+                                onClick={(e) => { e.stopPropagation(); openShare(list.id); }}
+                              >
+                                <i className="bi bi-share" />
+                              </button>
+                            )}
+                          </div>
                         )}
                       </div>
                     );

--- a/frontend/src/pages/EnhancedLists.test.jsx
+++ b/frontend/src/pages/EnhancedLists.test.jsx
@@ -1,0 +1,115 @@
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import fs from "fs";
+import path from "path";
+import EnhancedLists from "./EnhancedLists";
+import * as apiSafe from "../apiSafe";
+
+jest.mock("./AuthContext", () => ({
+  useAuth: () => ({
+    user: { id: 1, email: "owner@example.com" },
+    logout: jest.fn(),
+  }),
+}));
+
+jest.mock("../demo", () => ({
+  isDemo: () => false,
+  subscribeDemo: () => () => {},
+}));
+
+jest.mock("../api", () => ({
+  FEATURE_CATALOG: false,
+}));
+
+jest.mock("../apiSafe", () => ({
+  safeGetLists: jest.fn(),
+  safeGetItems: jest.fn(),
+  safeGetShares: jest.fn(),
+  safeAddItem: jest.fn(),
+  safeUpdateItem: jest.fn(),
+  safeDeleteItem: jest.fn(),
+  safeCreateList: jest.fn(),
+  safeRenameList: jest.fn(),
+  safeDeleteList: jest.fn(),
+  safeHideList: jest.fn(),
+  safeUnhideList: jest.fn(),
+  safeAddShare: jest.fn(),
+  safeUpdateShare: jest.fn(),
+  safeRevokeShare: jest.fn(),
+  safeGetShareLink: jest.fn(),
+}));
+
+jest.mock("../components/CategoryBadge", () => ({
+  __esModule: true,
+  default: () => null,
+  categoryColor: () => "#94a3b8",
+  categoryIcon: () => "bi-tag",
+}));
+
+jest.mock("../components/WeightDisplay", () => () => null);
+jest.mock("../components/PriceDisplay", () => () => null);
+jest.mock("../components/ItemTypeahead", () => () => <input aria-label="Item name" />);
+jest.mock("../components/BarcodeScanner", () => () => null);
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  apiSafe.safeGetLists.mockResolvedValue([]);
+  apiSafe.safeGetItems.mockResolvedValue([]);
+  apiSafe.safeGetShares.mockResolvedValue([]);
+  apiSafe.safeGetShareLink.mockResolvedValue("https://example.test/share/1");
+});
+
+test("keeps a manually created list visible when the refresh does not include it yet", async () => {
+  apiSafe.safeGetLists.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+  apiSafe.safeCreateList.mockResolvedValue({
+    id: 42,
+    name: "Weekend run",
+    owner_id: 1,
+    hidden: false,
+  });
+
+  render(<EnhancedLists />);
+
+  await screen.findByText("No lists yet");
+  fireEvent.change(screen.getByPlaceholderText(/new list/i), {
+    target: { value: "Weekend run" },
+  });
+
+  const createButton = screen.getByRole("button", { name: /create list/i });
+  expect(createButton).toBeEnabled();
+  fireEvent.click(createButton);
+
+  await waitFor(() => expect(apiSafe.safeCreateList).toHaveBeenCalledWith("Weekend run"));
+  const createdNames = await screen.findAllByText("Weekend run");
+  const createdRow = createdNames.map((node) => node.closest(".lm-list__item")).find(Boolean);
+  expect(createdRow).toBeInTheDocument();
+});
+
+test("keeps sidebar share action and item count in a non-overlapping trailing group", async () => {
+  apiSafe.safeGetLists.mockResolvedValueOnce([
+    { id: 7, name: "Groceries", owner_id: 1, hidden: false },
+  ]);
+  apiSafe.safeGetItems.mockResolvedValueOnce([
+    { id: 1, name: "Milk", quantity: 1, purchased: false },
+    { id: 2, name: "Bread", quantity: 1, purchased: true },
+  ]);
+
+  render(<EnhancedLists />);
+
+  const listNames = await screen.findAllByText("Groceries");
+  const listRow = listNames.map((node) => node.closest(".lm-list__item")).find(Boolean);
+  expect(listRow).not.toBeNull();
+
+  const actions = listRow.querySelector(".lm-list__item-actions");
+  expect(actions).not.toBeNull();
+  expect(within(actions).getByText("1")).toBeInTheDocument();
+  expect(within(actions).getByLabelText("Share Groceries")).toBeInTheDocument();
+});
+
+test("keeps sidebar share buttons visible in normal flow instead of overlay positioning", () => {
+  const css = fs.readFileSync(path.join(process.cwd(), "src", "theme.css"), "utf8");
+  const shareRule = css.match(/\.lm-list__item-share\s*\{([^}]*)\}/)?.[1] || "";
+
+  expect(shareRule).not.toMatch(/position:\s*absolute/);
+  expect(shareRule).not.toMatch(/opacity:\s*0\s*;/);
+  expect(shareRule).not.toMatch(/pointer-events:\s*none/);
+});

--- a/frontend/src/theme.css
+++ b/frontend/src/theme.css
@@ -1428,16 +1428,22 @@ textarea.form-control { resize: vertical; min-height: 60px; line-height: 1.5; }
 }
 
 /* ---------- 14f. Sidebar list quick-share button ----------------------- */
-.lm-list__item { position: relative; }
+.lm-list__item-actions {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.lm-list__item-actions .lm-badge {
+  flex-shrink: 0;
+}
 
 .lm-list__item-share {
-  position: absolute;
-  right: 10px;
-  top: 50%;
-  transform: translateY(-50%);
   width: 32px;
   height: 32px;
-  display: none;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
   border: 1px solid var(--border);
@@ -1446,15 +1452,16 @@ textarea.form-control { resize: vertical; min-height: 60px; line-height: 1.5; }
   border-radius: var(--radius-sm);
   font-size: 14px;
   cursor: pointer;
-  z-index: 2;
+  flex-shrink: 0;
   opacity: 0.85;
+  pointer-events: auto;
   transition: all var(--t-fast) var(--ease-out);
 }
 
 .lm-list__item:hover .lm-list__item-share,
 .lm-list__item:focus-within .lm-list__item-share,
 .lm-list__item.is-active .lm-list__item-share {
-  display: inline-flex;
+  opacity: 1;
 }
 
 .lm-list__item-share:hover {
@@ -1464,11 +1471,8 @@ textarea.form-control { resize: vertical; min-height: 60px; line-height: 1.5; }
   opacity: 1;
 }
 
-/* On touch devices there's no hover, so show the share button always when
-   the list item is in the visible viewport. We use a simple "always after
-   first item" approach via the list__item-share rule below. */
 @media (hover: none) {
-  .lm-list__item-share { display: inline-flex; opacity: 0.7; }
+  .lm-list__item-share { opacity: 0.7; pointer-events: auto; }
 }
 
 /* ---------- 14g. Mobile-only inline helpers ---------------------------- */


### PR DESCRIPTION
## Summary
- keep newly created lists visible after manual creation
- keep sidebar share action visible beside item counts without overlap
- add frontend regression coverage for list creation and share/count layout

## Tests
- npm test -- --watchAll=false
- npm run build