### PR TITLE
Make list create button always usable

### DIFF
--- a/frontend/src/pages/EnhancedLists.jsx
+++ b/frontend/src/pages/EnhancedLists.jsx
@@ -70,6 +70,16 @@ const daysUntil = (s) => {
   return Math.ceil((d - today) / (1000 * 60 * 60 * 24));
 };
 
+function nextNewListName(lists) {
+  const safeLists = Array.isArray(lists) ? lists : [];
+  const names = new Set(safeLists.map((list) => (list.name || "").trim().toLowerCase()).filter(Boolean));
+  if (!names.has("new list")) return "New list";
+
+  let next = 2;
+  while (names.has(`new list ${next}`)) next += 1;
+  return `New list ${next}`;
+}
+
 const ExpiryPill = ({ expiry }) => {
   const n = daysUntil(expiry);
   if (n === null) return <span className="lm-badge">No expiry</span>;
@@ -669,8 +679,7 @@ export default function EnhancedLists() {
 
   const onCreateList = async (e) => {
     e.preventDefault();
-    const nm = newListName.trim();
-    if (!nm) return;
+    const nm = newListName.trim() || nextNewListName(lists);
     try {
       setCreating(true);
       const created = await safeCreateList(nm);
@@ -1022,7 +1031,7 @@ export default function EnhancedLists() {
               <button
                 type="submit"
                 className="btn btn-primary btn-icon"
-                disabled={!newListName.trim() || creating}
+                disabled={creating}
                 aria-label="Create list"
                 title="Create list"
                 style={{ width: 40, height: 40 }}

--- a/frontend/src/pages/EnhancedLists.test.jsx
+++ b/frontend/src/pages/EnhancedLists.test.jsx
@@ -58,6 +58,28 @@ beforeEach(() => {
   apiSafe.safeGetShareLink.mockResolvedValue("https://example.test/share/1");
 });
 
+test("creates a manual list from the create button even when no name is typed yet", async () => {
+  apiSafe.safeGetLists.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+  apiSafe.safeCreateList.mockResolvedValue({
+    id: 41,
+    name: "New list",
+    owner_id: 1,
+    hidden: false,
+  });
+
+  render(<EnhancedLists />);
+
+  await screen.findByText("No lists yet");
+  const createButton = screen.getByRole("button", { name: /create list/i });
+  expect(createButton).toBeEnabled();
+  fireEvent.click(createButton);
+
+  await waitFor(() => expect(apiSafe.safeCreateList).toHaveBeenCalledWith("New list"));
+  const createdNames = await screen.findAllByText("New list");
+  const createdRow = createdNames.map((node) => node.closest(".lm-list__item")).find(Boolean);
+  expect(createdRow).toBeInTheDocument();
+});
+
 test("keeps a manually created list visible when the refresh does not include it yet", async () => {
   apiSafe.safeGetLists.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
   apiSafe.safeCreateList.mockResolvedValue({


### PR DESCRIPTION
Summary: keep the new-list create button enabled before a name is typed, create a default New list when clicked empty, and add regression coverage. Tests: npm test -- --watchAll=false; npm run build.